### PR TITLE
redis类从Extensions移动到Common

### DIFF
--- a/Blog.Core.Api/Blog.Core.xml
+++ b/Blog.Core.Api/Blog.Core.xml
@@ -729,7 +729,7 @@
             </summary>
             <returns></returns>
         </member>
-        <member name="M:Blog.Core.Controllers.ValuesController.RedisMq(Blog.Core.Extensions.IRedisBasketRepository)">
+        <member name="M:Blog.Core.Controllers.ValuesController.RedisMq(Blog.Core.Common.Redis.IRedisBasketRepository)">
             <summary>
             测试Redis消息队列
             </summary>

--- a/Blog.Core.Api/Controllers/ValuesController.cs
+++ b/Blog.Core.Api/Controllers/ValuesController.cs
@@ -2,10 +2,10 @@
 using Blog.Core.Common;
 using Blog.Core.Common.HttpContextUser;
 using Blog.Core.Common.HttpRestSharp;
+using Blog.Core.Common.Redis;
 using Blog.Core.Common.WebApiClients.HttpApis;
 using Blog.Core.EventBus;
 using Blog.Core.EventBus.EventHandling;
-using Blog.Core.Extensions;
 using Blog.Core.Filter;
 using Blog.Core.IServices;
 using Blog.Core.Model;
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
+
 
 namespace Blog.Core.Controllers
 {

--- a/Blog.Core.Common/Redis/Class1.cs
+++ b/Blog.Core.Common/Redis/Class1.cs
@@ -1,0 +1,6 @@
+﻿namespace Blog.Core.Common.Redis
+{
+    class Class12
+    {
+    }
+}

--- a/Blog.Core.Common/Redis/Class1.cs.bak
+++ b/Blog.Core.Common/Redis/Class1.cs.bak
@@ -1,0 +1,6 @@
+﻿namespace Blog.Core.Common.Redis
+{
+    class Class1
+    {
+    }
+}

--- a/Blog.Core.Common/Redis/IRedisBasketRepository.cs
+++ b/Blog.Core.Common/Redis/IRedisBasketRepository.cs
@@ -3,7 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
-namespace Blog.Core.Extensions
+namespace Blog.Core.Common.Redis
 {
     /// <summary>
     /// Redis缓存接口

--- a/Blog.Core.Common/Redis/IRedisCacheManager.cs
+++ b/Blog.Core.Common/Redis/IRedisCacheManager.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Blog.Core.Extensions
+namespace Blog.Core.Common.Redis
 {
     /// <summary>
     /// Redis缓存接口

--- a/Blog.Core.Common/Redis/RedisBasketRepository.cs
+++ b/Blog.Core.Common/Redis/RedisBasketRepository.cs
@@ -1,5 +1,4 @@
-﻿using Blog.Core.Common;
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using StackExchange.Redis;
 using System;
@@ -7,7 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
-namespace Blog.Core.Extensions
+namespace Blog.Core.Common.Redis
 {
     public class RedisBasketRepository : IRedisBasketRepository
     {

--- a/Blog.Core.Common/Redis/RedisCacheManager.cs
+++ b/Blog.Core.Common/Redis/RedisCacheManager.cs
@@ -1,8 +1,7 @@
-﻿using Blog.Core.Common;
-using StackExchange.Redis;
+﻿using StackExchange.Redis;
 using System;
 
-namespace Blog.Core.Extensions
+namespace Blog.Core.Common.Redis
 {
     public class RedisCacheManager : IRedisCacheManager
     {

--- a/Blog.Core.Common/Redis/RedisSubscribe.cs
+++ b/Blog.Core.Common/Redis/RedisSubscribe.cs
@@ -1,20 +1,13 @@
-﻿using Blog.Core.IServices;
-using InitQ.Abstractions;
+﻿using InitQ.Abstractions;
 using InitQ.Attributes;
 using System;
 using System.Threading.Tasks;
 
-namespace Blog.Core.Extensions.Redis
+namespace Blog.Core.Common.Redis
 {
     public class RedisSubscribe : IRedisSubscribe
     {
-        private readonly IBlogArticleServices _blogArticleServices;
-
-        public RedisSubscribe(IBlogArticleServices blogArticleServices)
-        {
-            _blogArticleServices = blogArticleServices;
-        }
-
+      
         [Subscribe(RedisMqKey.Loging)]
         private async Task SubRedisLoging(string msg)
         {

--- a/Blog.Core.Common/Redis/RedisSubscribe2.cs
+++ b/Blog.Core.Common/Redis/RedisSubscribe2.cs
@@ -3,7 +3,7 @@ using InitQ.Attributes;
 using System;
 using System.Threading.Tasks;
 
-namespace Blog.Core.Extensions.Redis
+namespace Blog.Core.Common.Redis
 {
     public class RedisSubscribe2 : IRedisSubscribe
     {

--- a/Blog.Core.Extensions/AOP/BlogRedisCacheAOP.cs
+++ b/Blog.Core.Extensions/AOP/BlogRedisCacheAOP.cs
@@ -1,4 +1,5 @@
 ﻿using Blog.Core.Common;
+using Blog.Core.Common.Redis;
 using Blog.Core.Extensions;
 using Castle.DynamicProxy;
 using System;

--- a/Blog.Core.Extensions/ServiceExtensions/RedisCacheSetup.cs
+++ b/Blog.Core.Extensions/ServiceExtensions/RedisCacheSetup.cs
@@ -1,4 +1,5 @@
 ﻿using Blog.Core.Common;
+using Blog.Core.Common.Redis;
 using Microsoft.Extensions.DependencyInjection;
 using StackExchange.Redis;
 using System;

--- a/Blog.Core.Extensions/ServiceExtensions/RedisInitMqSetup.cs
+++ b/Blog.Core.Extensions/ServiceExtensions/RedisInitMqSetup.cs
@@ -1,5 +1,5 @@
 ﻿using Blog.Core.Common;
-using Blog.Core.Extensions.Redis;
+using Blog.Core.Common.Redis;
 using InitQ;
 using Microsoft.Extensions.DependencyInjection;
 using System;

--- a/Blog.Core.Services/AccessTrendLogServices.cs.bak
+++ b/Blog.Core.Services/AccessTrendLogServices.cs.bak
@@ -12,7 +12,7 @@ namespace Blog.Core.Services
         {
             this._dal = dal;
             base.BaseDal = dal;
-        }    
+        }
 
     }
 }


### PR DESCRIPTION
redis类从Extensions移动到Common，
解决service不能调用IRedisBasketRepository的问题