### PR TITLE
修改DeleteById(object id) 低版本报错问题

### DIFF
--- a/Blog.Core.Repository/BASE/BaseRepository.cs
+++ b/Blog.Core.Repository/BASE/BaseRepository.cs
@@ -200,7 +200,7 @@ namespace Blog.Core.Repository.Base
         /// <returns></returns>
         public async Task<bool> DeleteById(object id)
         {
-            return await _db.Deleteable<TEntity>(id).ExecuteCommandHasChangeAsync();
+            return await _db.Deleteable<TEntity>().In(id).ExecuteCommandHasChangeAsync();
         }
 
         /// <summary>


### PR DESCRIPTION
本地测试低版本的sqlsugar调用DeleteById(object id) 会报错，直接升级版本可以解决问题，不升级修改一下调用方法