### PR TITLE
增加实体表GblLogAudit，结构化日志记录 LogType 系统内定义的五种审计日志AOPLog、RequestResponseLo…

### DIFF
--- a/Blog.Core.Api/Log4net.config
+++ b/Blog.Core.Api/Log4net.config
@@ -402,6 +402,83 @@
 	</appender>
 	<!--MSSQL记录 end######################################################################################################################################## -->
 
+	<!--MSSQL 结构化记录日志 begin######################################################################################################################################## -->
+	<!--2022/09/05 原因：增加可读性，结构化日志记录,PR2022/10/11-->
+	<!--访问结果错误记录-->
+	<appender name="AdoNetAppenderStructured" type="MicroKnights.Logging.AdoNetAppender, MicroKnights.Log4NetAdoNetAppender">
+		<bufferSize value="1" />
+		<connectionType value="Microsoft.Data.SqlClient.SqlConnection, Microsoft.Data.SqlClient, Version=1.0.0.0,Culture=neutral,PublicKeyToken=23ec7fc2d6eaa4a5"/>
+		<connectionStringName value="sqlserver" />
+		<!--<connectionStringFile value="connectionstrings.json" />-->
+		<!--两者二选一(connectionStringName/connectionStringFile)，使用上面的方式需要添加一个connectionstrings.json文件,上面的方式找不到数据库的情况下报错导致启动时间变长，不适用，弃用，后面都是直接在下面字符串配置-->
+		<!--<connectionString value="Server=xxxxxx;Database=xxxxxx;User Id=xx;Password=xxxxxx;" />-->
+		<commandText value="INSERT INTO GblLogAudit ([Date],[Thread],[Level],[Logger],[LogType],[DataType],[Message],[Exception]) VALUES (@log_date, @thread, @log_level, @logger,@logType,@dataType, @message, @exception)" />
+		<parameter>
+			<parameterName value="@log_date" />
+			<dbType value="DateTime" />
+			<layout type="log4net.Layout.RawTimeStampLayout" />
+		</parameter>
+		<parameter>
+			<parameterName value="@thread" />
+			<dbType value="String" />
+			<size value="255" />
+			<layout type="log4net.Layout.PatternLayout">
+				<conversionPattern value="%thread" />
+			</layout>
+		</parameter>
+		<parameter>
+			<parameterName value="@log_level" />
+			<dbType value="String" />
+			<size value="50" />
+			<layout type="log4net.Layout.PatternLayout">
+				<conversionPattern value="%level" />
+			</layout>
+		</parameter>
+		<parameter>
+			<parameterName value="@logger" />
+			<dbType value="String" />
+			<size value="255" />
+			<layout type="log4net.Layout.PatternLayout">
+				<conversionPattern value="%logger" />
+			</layout>
+		</parameter>
+		<parameter>
+			<parameterName value="@logType" />
+			<dbType value="String" />
+			<size value="50" />
+			<layout type="log4net.Layout.PatternLayout">
+				<conversionPattern value="%property{LogType}" />
+			</layout>
+		</parameter>
+		<parameter>
+			<parameterName value="@dataType" />
+			<dbType value="String" />
+			<size value="255" />
+			<layout type="log4net.Layout.PatternLayout">
+				<conversionPattern value="%property{DataType}" />
+			</layout>
+		</parameter>
+		<parameter>
+			<parameterName value="@message" />
+			<dbType value="String" />
+			<size value="999999999" />
+			<layout type="log4net.Layout.PatternLayout">
+				<conversionPattern value="%message" />
+			</layout>
+		</parameter>
+		<parameter>
+			<parameterName value="@exception" />
+			<dbType value="String" />
+			<size value="999999999" />
+			<layout type="log4net.Layout.ExceptionLayout" />
+		</parameter>
+		<filter type="log4net.Filter.LevelRangeFilter">
+			<levelMin value="DEBUG" />
+			<levelMax value="FATAL" />
+		</filter>
+	</appender>
+	<!--MSSQL 结构化记录日志 end######################################################################################################################################## -->
+
 	<!--启用记录器-->
 	<root>
 		<!-- 控制级别，由低到高：ALL|DEBUG|INFO|WARN|ERROR|FATAL|OFF -->
@@ -421,9 +498,10 @@
 		<appender-ref ref="MongoDBAppendererror" />-->
 
 		<!--MSSQL日志-->
-		<appender-ref ref="AdoNetAppenderError" />
+		<!--<appender-ref ref="AdoNetAppenderError" />
 		<appender-ref ref="AdoNetAppenderDebug" />
-		<appender-ref ref="AdoNetAppenderInfo" />
+		<appender-ref ref="AdoNetAppenderInfo" />-->
+		<appender-ref ref="AdoNetAppenderStructured" />
 	</root>
 	<!--启用记录器-->
 </log4net>

--- a/Blog.Core.Api/appsettings.json
+++ b/Blog.Core.Api/appsettings.json
@@ -52,22 +52,28 @@
       "Enabled": true
     },
     "LogAOP": {
-      "Enabled": false
+      "Enabled": true,
+      "LogToFile": {
+        "Enabled": true
+      },
+      "LogToDB": {
+        "Enabled": true
+      }
     },
     "TranAOP": {
       "Enabled": true
     },
     "SqlAOP": {
       "Enabled": true,
-      "OutToLogFile": {
+      "LogToFile": {
         "Enabled": false
       },
-      "OutToConsole": {
+      "LogToDB": {
+        "Enabled": false
+      },
+      "LogToConsole": {
         "Enabled": true
       }
-    },
-    "LogToDb": {
-      "Enabled": true
     },
     "Date": "2018-08-28",
     "SeedDBEnabled": true, //只生成表结构
@@ -194,13 +200,31 @@
   },
   "Middleware": {
     "RequestResponseLog": {
-      "Enabled": false
+      "Enabled": true,
+      "LogToFile": {
+        "Enabled": true
+      },
+      "LogToDB": {
+        "Enabled": true
+      }
     },
     "IPLog": {
-      "Enabled": true
+      "Enabled": true,
+      "LogToFile": {
+        "Enabled": true
+      },
+      "LogToDB": {
+        "Enabled": true
+      }
     },
     "RecordAccessLogs": {
       "Enabled": true,
+      "LogToFile": {
+        "Enabled": true
+      },
+      "LogToDB": {
+        "Enabled": true
+      },
       "IgnoreApis": "/api/permission/getnavigationbar,/api/monitor/getids4users,/api/monitor/getaccesslogs,/api/monitor/server,/api/monitor/getactiveusers,/api/monitor/server,"
     },
     "SignalR": {

--- a/Blog.Core.Common/LogHelper/RequestInfo.cs
+++ b/Blog.Core.Common/LogHelper/RequestInfo.cs
@@ -40,7 +40,7 @@ namespace Blog.Core.Common.LogHelper
 
     }
 
-    public class ApiLogAopInfo
+    public class AOPLogInfo
     {
         /// <summary>
         /// 请求时间
@@ -76,9 +76,9 @@ namespace Blog.Core.Common.LogHelper
         public string ResponseJsonData { get; set; } = string.Empty;
     }
 
-    public class ApiLogAopExInfo
+    public class AOPLogExInfo
     {
-        public ApiLogAopInfo ApiLogAopInfo { get; set; }
+        public AOPLogInfo ApiLogAopInfo { get; set; }
         /// <summary>
         /// 异常
         /// </summary>
@@ -87,5 +87,23 @@ namespace Blog.Core.Common.LogHelper
         /// 异常信息
         /// </summary>
         public string ExMessage { get; set; } = string.Empty;
+    }
+
+    public class RequestLogInfo
+    {
+        /// <summary>
+        /// 请求地址
+        /// </summary>
+        public string Path { get; set; }
+
+        /// <summary>
+        /// 请求参数
+        /// </summary>
+        public string QueryString { get; set; }
+
+        /// <summary>
+        /// Body参数
+        /// </summary>
+        public string BodyData { get; set; }
     }
 }

--- a/Blog.Core.Extensions/AOP/BlogLogAOP.cs
+++ b/Blog.Core.Extensions/AOP/BlogLogAOP.cs
@@ -45,7 +45,7 @@ namespace Blog.Core.AOP
                 json = "无法序列化，可能是兰姆达表达式等原因造成，按照框架优化代码" + ex.ToString();
             }
             DateTime startTime = DateTime.Now;
-            ApiLogAopInfo apiLogAopInfo = new ApiLogAopInfo
+            AOPLogInfo apiLogAopInfo = new AOPLogInfo
             {
                 RequestTime = startTime.ToString("yyyy-MM-dd hh:mm:ss fff"),
                 OpUserName = UserName,
@@ -103,7 +103,7 @@ namespace Blog.Core.AOP
 
 
                     // 如果方案一不行，试试这个方案
-                    #region 方案二
+                    //#region 方案二
 
                     //var type = invocation.Method.ReturnType;
                     //var resultProperty = type.GetProperty("Result");
@@ -120,10 +120,10 @@ namespace Blog.Core.AOP
                     //Parallel.For(0, 1, e =>
                     //{
                     //    //LogLock.OutLogAOP("AOPLog", new string[] { dataIntercept });
-                    //    LogLock.OutSql2Log("AOPLog", new string[] { JsonConvert.SerializeObject(apiLogAopInfo) });
+                    //    LogLock.OutLogAOP("AOPLog", new string[] { apiLogAopInfo.GetType().ToString() + " - ResponseJsonDataType:" + type, JsonConvert.SerializeObject(apiLogAopInfo) });
                     //});
 
-                    #endregion
+                    //#endregion
                 }
                 else
                 {
@@ -137,10 +137,19 @@ namespace Blog.Core.AOP
                     {
                         jsonResult = "无法序列化，可能是兰姆达表达式等原因造成，按照框架优化代码" + ex.ToString();
                     }
+                    var type = invocation.Method.ReturnType;
+                    var resultProperty = type.GetProperty("Result");
+                    DateTime endTime = DateTime.Now;
+                    string ResponseTime = (endTime - startTime).Milliseconds.ToString();
+                    apiLogAopInfo.ResponseTime = endTime.ToString("yyyy-MM-dd hh:mm:ss fff");
+                    apiLogAopInfo.ResponseIntervalTime = ResponseTime + "ms";
+                    //apiLogAopInfo.ResponseJsonData = JsonConvert.SerializeObject(resultProperty.GetValue(invocation.ReturnValue));
                     apiLogAopInfo.ResponseJsonData = jsonResult;
+                    //dataIntercept += ($"【执行完成结果】：{jsonResult}");
                     Parallel.For(0, 1, e =>
                     {
-                        LogLock.OutSql2Log("AOPLog", new string[] { JsonConvert.SerializeObject(apiLogAopInfo) });
+                        //LogLock.OutLogAOP("AOPLog", new string[] { dataIntercept });
+                        LogLock.OutLogAOP("AOPLog", new string[] { apiLogAopInfo.GetType().ToString(), JsonConvert.SerializeObject(apiLogAopInfo) });
                     });
                 }
             }
@@ -154,7 +163,7 @@ namespace Blog.Core.AOP
             }
         }
 
-        private async Task SuccessAction(IInvocation invocation, ApiLogAopInfo apiLogAopInfo, DateTime startTime, object o = null)
+        private async Task SuccessAction(IInvocation invocation, AOPLogInfo apiLogAopInfo, DateTime startTime, object o = null)
         {
             //invocation.ReturnValue = o;
             //var type = invocation.Method.ReturnType;
@@ -179,12 +188,13 @@ namespace Blog.Core.AOP
             {
                 Parallel.For(0, 1, e =>
                 {
-                    LogLock.OutSql2Log("AOPLog", new string[] { JsonConvert.SerializeObject(apiLogAopInfo) });
+                    //LogLock.OutSql2Log("AOPLog", new string[] { JsonConvert.SerializeObject(apiLogAopInfo) });
+                    LogLock.OutLogAOP("AOPLog", new string[] { apiLogAopInfo.GetType().ToString(), JsonConvert.SerializeObject(apiLogAopInfo) });
                 });
             });
         }
 
-        private void LogEx(Exception ex, ApiLogAopInfo apiLogAopInfo)
+        private void LogEx(Exception ex, AOPLogInfo dataIntercept)
         {
             if (ex != null)
             {
@@ -192,16 +202,18 @@ namespace Blog.Core.AOP
                 MiniProfiler.Current.CustomTiming("Errors：", ex.Message);
                 //执行的 service 中，捕获异常
                 //dataIntercept += ($"【执行完成结果】：方法中出现异常：{ex.Message + ex.InnerException}\r\n");
-                ApiLogAopExInfo apiLogAopExInfo = new ApiLogAopExInfo
+                AOPLogExInfo apiLogAopExInfo = new AOPLogExInfo
                 {
                     ExMessage = ex.Message,
-                    InnerException = ex.InnerException.ToString(),
-                    ApiLogAopInfo = apiLogAopInfo
+                    InnerException = "InnerException-内部异常:\r\n" + (ex.InnerException == null ? "" : ex.InnerException.InnerException.ToString()) + ("\r\nStackTrace-堆栈跟踪:\r\n") + (ex.StackTrace == null ? "" : ex.StackTrace.ToString()),
+                    ApiLogAopInfo = dataIntercept
                 };
                 // 异常日志里有详细的堆栈信息
                 Parallel.For(0, 1, e =>
                 {
-                    LogLock.OutSql2Log("AOPLog", new string[] { JsonConvert.SerializeObject(apiLogAopExInfo) });
+                    //LogLock.OutLogAOP("AOPLogEx", new string[] { dataIntercept });
+                    LogLock.OutLogAOP("AOPLogEx", new string[] { apiLogAopExInfo.GetType().ToString(), JsonConvert.SerializeObject(apiLogAopExInfo) });
+
                 });
             }
         }

--- a/Blog.Core.Extensions/Blog.Core.Extensions.csproj
+++ b/Blog.Core.Extensions/Blog.Core.Extensions.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Log4Net.AspNetCore" Version="6.1.0" />
     <PackageReference Include="MiniProfiler.AspNetCore.Mvc" Version="4.2.22" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="7.0.5" />
 

--- a/Blog.Core.Extensions/Middlewares/IpLogMiddleware.cs
+++ b/Blog.Core.Extensions/Middlewares/IpLogMiddleware.cs
@@ -44,6 +44,7 @@ namespace Blog.Core.Extensions.Middlewares
                     {
                         // 存储请求数据
                         var request = context.Request;
+
                         var requestInfo = JsonConvert.SerializeObject(new RequestInfo()
                         {
                             Ip = GetClientIP(context),
@@ -58,7 +59,8 @@ namespace Blog.Core.Extensions.Middlewares
                             // 自定义log输出
                             Parallel.For(0, 1, e =>
                             {
-                                LogLock.OutSql2Log("RequestIpInfoLog", new string[] { requestInfo + "," }, false);
+                                //LogLock.OutSql2Log("RequestIpInfoLog", new string[] { requestInfo + "," }, false);
+                                LogLock.OutLogAOP("RequestIpInfoLog", new string[] { requestInfo.GetType().ToString(), requestInfo }, false);
                             });
 
                             //try

--- a/Blog.Core.Extensions/Middlewares/RecordAccessLogsMiddleware.cs
+++ b/Blog.Core.Extensions/Middlewares/RecordAccessLogsMiddleware.cs
@@ -106,15 +106,13 @@ namespace Blog.Core.Extensions.Middlewares
 
                         // 自定义log输出
                         var requestInfo = JsonConvert.SerializeObject(userAccessModel);
-                        //Parallel.For(0, 1, e =>
-                        //{
-                        //    LogLock.OutSql2Log("RecordAccessLogs", new string[] { requestInfo + "," }, false);
-                        //});
-
-                        var logFileName = FileHelper.GetAvailableFileNameWithPrefixOrderSize(_environment.ContentRootPath, "RecordAccessLogs");
-                        SerilogServer.WriteLog(logFileName, new string[] { requestInfo + "," }, false);
-                       
-
+                        Parallel.For(0, 1, e =>
+                        {
+                            //LogLock.OutSql2Log("RecordAccessLogs", new string[] { requestInfo + "," }, false);
+                            LogLock.OutLogAOP("RecordAccessLogs", new string[] { userAccessModel.GetType().ToString(), requestInfo }, false);
+                        });
+                        //var logFileName = FileHelper.GetAvailableFileNameWithPrefixOrderSize(_environment.ContentRootPath, "RecordAccessLogs");
+                        //SerilogServer.WriteLog(logFileName, new string[] { requestInfo + "," }, false);
                         return Task.CompletedTask;
                     });
 

--- a/Blog.Core.Extensions/Middlewares/RequRespLogMiddleware.cs
+++ b/Blog.Core.Extensions/Middlewares/RequRespLogMiddleware.cs
@@ -6,6 +6,8 @@ using Blog.Core.Common;
 using Blog.Core.Common.LogHelper;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Ubiety.Dns.Core.Common;
 
 namespace Blog.Core.Extensions.Middlewares
 {
@@ -86,17 +88,24 @@ namespace Blog.Core.Extensions.Middlewares
         {
             var request = context.Request;
             var sr = new StreamReader(request.Body);
-
-            var content = $" QueryData:{request.Path + request.QueryString}\r\n BodyData:{await sr.ReadToEndAsync()}";
+            RequestLogInfo requestResponse = new RequestLogInfo()
+            {
+                Path = request.Path,
+                QueryString = request.QueryString.ToString(),
+                BodyData = await sr.ReadToEndAsync()
+            };
+            var content = JsonConvert.SerializeObject(requestResponse);
+            //var content = $" QueryData:{request.Path + request.QueryString}\r\n BodyData:{await sr.ReadToEndAsync()}";
 
             if (!string.IsNullOrEmpty(content))
             {
-                //Parallel.For(0, 1, e =>
-                //{
-                //    LogLock.OutSql2Log("RequestResponseLog", new string[] { "Request Data:", content });
+                Parallel.For(0, 1, e =>
+                {
+                    //LogLock.OutSql2Log("RequestResponseLog", new string[] { "Request Data:", content });
+                    LogLock.OutLogAOP("RequestResponseLog", new string[] { "Request Data -  RequestJsonDataType:" + requestResponse.GetType().ToString(), content });
 
-                //});
-                SerilogServer.WriteLog("RequestResponseLog", new string[] { "Request Data:", content });
+                });
+                //SerilogServer.WriteLog("RequestResponseLog", new string[] { "Request Data:", content });
 
                 request.Body.Position = 0;
             }
@@ -113,12 +122,13 @@ namespace Blog.Core.Extensions.Middlewares
 
             if (!string.IsNullOrEmpty(responseBody))
             {
-                //Parallel.For(0, 1, e =>
-                //{
-                //    LogLock.OutSql2Log("RequestResponseLog", new string[] { "Response Data:", ResponseBody });
+                Parallel.For(0, 1, e =>
+                {
+                    //LogLock.OutSql2Log("RequestResponseLog", new string[] { "Response Data:", ResponseBody });
+                    LogLock.OutLogAOP("RequestResponseLog", new string[] { "Response Data -  ResponseJsonDataType:" + responseBody.GetType().ToString(), responseBody });
 
-                //});
-                SerilogServer.WriteLog("RequestResponseLog", new string[] { "Response Data:", responseBody });
+                });
+                //SerilogServer.WriteLog("RequestResponseLog", new string[] { "Response Data:", responseBody });
             }
         }
     }

--- a/Blog.Core.Extensions/ServiceExtensions/SqlsugarSetup.cs
+++ b/Blog.Core.Extensions/ServiceExtensions/SqlsugarSetup.cs
@@ -66,7 +66,8 @@ namespace Blog.Core.Extensions
                                         Parallel.For(0, 1, e =>
                                         {
                                             MiniProfiler.Current.CustomTiming("SQL：", GetParas(p) + "【SQL语句】：" + sql);
-                                            LogLock.OutSql2Log("SqlLog", new string[] { GetParas(p), "【SQL语句】：" + sql });
+                                            //LogLock.OutSql2Log("SqlLog", new string[] { GetParas(p), "【SQL语句】：" + sql });
+                                            LogLock.OutLogAOP("SqlLog", new string[] { sql.GetType().ToString(), GetParas(p), "【SQL语句】：" + sql });
 
                                         });
                                     }

--- a/Blog.Core.Model/Models/GblLogAudit.cs
+++ b/Blog.Core.Model/Models/GblLogAudit.cs
@@ -1,0 +1,64 @@
+﻿using SqlSugar;
+using System;
+
+namespace Blog.Core.Model.Models
+{
+    /// <summary>
+    /// 用户团队表
+    /// </summary>
+    [SugarTable("GblLogAudit", TableDescription = "日志审计")]
+    public class GblLogAudit
+    {
+        ///<summary>
+        ///ID
+        ///</summary>
+        [SugarColumn(ColumnDescription = "ID", IsNullable = false, IsPrimaryKey = false, IsIdentity = true)]
+        public int Id { get; set; }
+
+        ///<summary>
+        ///时间
+        ///</summary>
+        [SugarColumn(ColumnDescription = "时间", IsNullable = false, IsPrimaryKey = false, IsIdentity = false, ColumnDataType = "datetime")]
+        public DateTime Date { get; set; } = DateTime.Now;
+
+        ///<summary>
+        ///线程
+        ///</summary>
+        [SugarColumn(ColumnDescription = "线程", IsNullable = false, IsPrimaryKey = false, IsIdentity = false, ColumnDataType = "varchar", Length = 255)]
+        public string Thread { get; set; }
+
+        ///<summary>
+        ///等级
+        ///</summary>
+        [SugarColumn(ColumnDescription = "等级", IsNullable = false, IsPrimaryKey = false, IsIdentity = false, ColumnDataType = "varchar", Length = 255)]
+        public string Level { get; set; }
+        ///<summary>
+        ///记录器
+        ///</summary>
+        [SugarColumn(ColumnDescription = "记录器", IsNullable = false, IsPrimaryKey = false, IsIdentity = false, ColumnDataType = "varchar", Length = 255)]
+        public string Logger { get; set; }
+        ///<summary>
+        ///日志类型
+        ///</summary>
+        [SugarColumn(ColumnDescription = "日志类型", IsNullable = false, IsPrimaryKey = false, IsIdentity = false, ColumnDataType = "varchar", Length = 255)]
+        public string LogType { get; set; }
+        ///<summary>
+        ///数据类型
+        ///</summary>
+        [SugarColumn(ColumnDescription = "数据类型", IsNullable = false, IsPrimaryKey = false, IsIdentity = false, ColumnDataType = "varchar", Length = 255)]
+        public string DataType { get; set; }
+
+        ///<summary>
+        ///错误信息
+        ///</summary>
+        [SugarColumn(ColumnDescription = "错误信息", IsNullable = false, IsPrimaryKey = false, IsIdentity = false, ColumnDataType = "text")]
+        public string Message { get; set; }
+
+        ///<summary>
+        ///异常
+        ///</summary>
+        [SugarColumn(ColumnDescription = "异常", IsNullable = true, IsPrimaryKey = false, IsIdentity = false, ColumnDataType = "text")]
+        public string Exception { get; set; }
+
+    }
+}

--- a/Blog.Core.Model/Models/TopicDetail.cs
+++ b/Blog.Core.Model/Models/TopicDetail.cs
@@ -19,7 +19,7 @@ namespace Blog.Core.Model.Models
         [SugarColumn(Length = 200, IsNullable = true)]
         public string tdName { get; set; }
 
-        [SugarColumn(Length = 2000, IsNullable = true)]
+        [SugarColumn(Length = 6000, IsNullable = true)]
         public string tdContent { get; set; }
 
         [SugarColumn(Length = 2000, IsNullable = true)]

--- a/Blog.Core.Model/Models/sysUserInfo.cs
+++ b/Blog.Core.Model/Models/sysUserInfo.cs
@@ -36,6 +36,8 @@ namespace Blog.Core.Model.Models
         //[SugarColumn(IsNullable = false, ColumnDescription = "登录账号", IsPrimaryKey = false, IsIdentity = false, ColumnDataType = "nvarchar", Length = 50)]
         //ColumnDescription 表字段备注，  已在MSSQL测试，配合 [SugarTable("SysUserInfo", "用户表")]//('数据库表名'，'数据库表备注')
         //可以完整生成 表备注和各个字段的中文备注
+        //2022/10/11
+        //测试mssql 发现 不写ColumnDescription，写好注释在mssql下也能生成表字段备注
         public string LoginName { get; set; }
 
         /// <summary>

--- a/Blog.Core.Tasks/QuartzNet/Jobs/Job_AccessTrendLog_Quartz.cs
+++ b/Blog.Core.Tasks/QuartzNet/Jobs/Job_AccessTrendLog_Quartz.cs
@@ -93,7 +93,7 @@ namespace Blog.Core.Tasks
 
             Parallel.For(0, 1, e =>
             {
-                LogLock.OutSql2Log("ACCESSTRENDLOG", new string[] { JsonConvert.SerializeObject(activeUserVMs) }, false, true);
+                LogLock.OutLogAOP("ACCESSTRENDLOG", new string[] { activeUserVMs.GetType().ToString(), JsonConvert.SerializeObject(activeUserVMs) }, false, true);
             });
         }
 


### PR DESCRIPTION
…g、RequestIpInfoLog、RequestResponseLog、RecordAccessLogs

DataType ： 记录日志的数据类型Blog.Core.Common.LogHelper.AOPLogInfo...... 配置文件修改，删除“LogToDb”配置节点
LogAOP、SqlAOP、RequestResponseLog、IPLog、RecordAccessLogs增加都增加两个开关 “LogToFile”和“LogToDB”，用于分别单独控制每个日志类型记录文件还是数据库，还是同时都记录 可以采取环境变量读取不同appsettings.json 进行不同环境记录日志不同
我目前主要采取开发环境双边记录，日志和数据库，Production生产环境只记录数据库
![image](https://user-images.githubusercontent.com/24422140/200226650-2e18463b-eb4e-4432-a444-a9b80cdbdaa7.png)
![image](https://user-images.githubusercontent.com/24422140/200226691-20832438-8d7f-4611-a909-675862c7f089.png)
![image](https://user-images.githubusercontent.com/24422140/200226777-6a0cf95d-176d-4475-bdda-aed1d445000b.png)
![image](https://user-images.githubusercontent.com/24422140/200226811-cd8abbb8-d7e9-478a-b190-41a204c4b01e.png)

