### PR TITLE
日志审计加入TraceId

### DIFF
--- a/Blog.Core.Api/Blog.Core.Model.xml
+++ b/Blog.Core.Api/Blog.Core.Model.xml
@@ -386,6 +386,11 @@
             ID
             </summary>
         </member>
+        <member name="P:Blog.Core.Model.Models.GblLogAudit.TraceId">
+            <summary>
+            HttpContext.TraceIdentifier 事件链路ID（获取或设置一个唯一标识符，用于在跟踪日志中表示此请求。）
+            </summary>
+        </member>
         <member name="P:Blog.Core.Model.Models.GblLogAudit.Date">
             <summary>
             时间

--- a/Blog.Core.Api/Log4net.config
+++ b/Blog.Core.Api/Log4net.config
@@ -7,7 +7,7 @@
 		<connectionType value="Microsoft.Data.Sqlite.SqliteConnection, Microsoft.Data.Sqlite, Version=7.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60" />
 		<connectionStringName value="sqlite" />
 		<connectionString value="Data Source=WMBlog.db" />
-		<commandText value="INSERT INTO GblLogAudit ([Date],[Thread],[Level],[Logger],[LogType],[DataType],[Message],[Exception]) VALUES (@log_date, @thread, @log_level, @logger,@logType,@dataType, @message, @exception)" />
+		<commandText value="INSERT INTO GblLogAudit ([Date],[Thread],[Level],[Logger],[LogType],[DataType],[Message],[Exception],[TraceId]) VALUES (@log_date, @thread, @log_level, @logger,@logType,@dataType, @message, @exception,@traceId)" />
 		<parameter>
 			<parameterName value="@log_date" />
 			<dbType value="DateTime" />
@@ -66,6 +66,14 @@
 			<dbType value="String" />
 			<size value="999999999" />
 			<layout type="log4net.Layout.ExceptionLayout" />
+		</parameter>
+		<parameter>
+			<parameterName value="@traceId" />
+			<dbType value="String" />
+			<size value="255" />
+			<layout type="log4net.Layout.PatternLayout">
+				<conversionPattern value="%property{TraceId}" />
+			</layout>
 		</parameter>
 		<filter type="log4net.Filter.LevelRangeFilter">
 			<levelMin value="DEBUG" />

--- a/Blog.Core.Common/LogHelper/LogLock.cs
+++ b/Blog.Core.Common/LogHelper/LogLock.cs
@@ -23,7 +23,7 @@ namespace Blog.Core.Common.LogHelper
             _contentRoot = contentPath;
         }
 
-        public static void OutLogAOP(string prefix, string[] dataParas, bool IsHeader = true, bool isWrt = false)
+        public static void OutLogAOP(string prefix, string traceId, string[] dataParas, bool IsHeader = true)
         {
             string AppSetingNodeName = "AppSettings";
             string AppSetingName = "LogAOP";
@@ -57,11 +57,11 @@ namespace Blog.Core.Common.LogHelper
             {
                 if (AppSettings.app(new string[] { AppSetingNodeName, AppSetingName, "LogToDB", "Enabled" }).ObjToBool())
                 {
-                    OutSql2LogToDB(prefix, dataParas, IsHeader);
+                    OutSql2LogToDB(prefix, traceId, dataParas, IsHeader);
                 }
                 if (AppSettings.app(new string[] { AppSetingNodeName, AppSetingName, "LogToFile", "Enabled" }).ObjToBool())
                 {
-                    OutSql2LogToFile(prefix, dataParas, IsHeader);
+                    OutSql2LogToFile(prefix, traceId, dataParas, IsHeader);
                 }
             }
 
@@ -75,7 +75,7 @@ namespace Blog.Core.Common.LogHelper
             //}
         }
 
-        public static void OutSql2LogToFile(string prefix, string[] dataParas, bool IsHeader = true, bool isWrt = false)
+        public static void OutSql2LogToFile(string prefix, string traceId, string[] dataParas, bool IsHeader = true, bool isWrt = false)
         {
             try
             {
@@ -170,9 +170,10 @@ namespace Blog.Core.Common.LogHelper
                 LogWriteLock.ExitWriteLock();
             }
         }
-        public static void OutSql2LogToDB(string prefix, string[] dataParas, bool IsHeader = true)
+        public static void OutSql2LogToDB(string prefix, string traceId, string[] dataParas, bool IsHeader = true)
         {
             log4net.LogicalThreadContext.Properties["LogType"] = prefix;
+            log4net.LogicalThreadContext.Properties["TraceId"] = traceId;
             if (dataParas.Length >= 2)
             {
                 log4net.LogicalThreadContext.Properties["DataType"] = dataParas[0];

--- a/Blog.Core.Extensions/AOP/BlogLogAOP.cs
+++ b/Blog.Core.Extensions/AOP/BlogLogAOP.cs
@@ -149,7 +149,7 @@ namespace Blog.Core.AOP
                     Parallel.For(0, 1, e =>
                     {
                         //LogLock.OutLogAOP("AOPLog", new string[] { dataIntercept });
-                        LogLock.OutLogAOP("AOPLog", new string[] { apiLogAopInfo.GetType().ToString(), JsonConvert.SerializeObject(apiLogAopInfo) });
+                        LogLock.OutLogAOP("AOPLog", _accessor.HttpContext?.TraceIdentifier, new string[] { apiLogAopInfo.GetType().ToString(), JsonConvert.SerializeObject(apiLogAopInfo) });
                     });
                 }
             }
@@ -189,7 +189,7 @@ namespace Blog.Core.AOP
                 Parallel.For(0, 1, e =>
                 {
                     //LogLock.OutSql2Log("AOPLog", new string[] { JsonConvert.SerializeObject(apiLogAopInfo) });
-                    LogLock.OutLogAOP("AOPLog", new string[] { apiLogAopInfo.GetType().ToString(), JsonConvert.SerializeObject(apiLogAopInfo) });
+                    LogLock.OutLogAOP("AOPLog", _accessor.HttpContext?.TraceIdentifier, new string[] { apiLogAopInfo.GetType().ToString(), JsonConvert.SerializeObject(apiLogAopInfo) });
                 });
             });
         }
@@ -212,7 +212,7 @@ namespace Blog.Core.AOP
                 Parallel.For(0, 1, e =>
                 {
                     //LogLock.OutLogAOP("AOPLogEx", new string[] { dataIntercept });
-                    LogLock.OutLogAOP("AOPLogEx", new string[] { apiLogAopExInfo.GetType().ToString(), JsonConvert.SerializeObject(apiLogAopExInfo) });
+                    LogLock.OutLogAOP("AOPLogEx", _accessor.HttpContext?.TraceIdentifier, new string[] { apiLogAopExInfo.GetType().ToString(), JsonConvert.SerializeObject(apiLogAopExInfo) });
 
                 });
             }

--- a/Blog.Core.Extensions/Middlewares/IpLogMiddleware.cs
+++ b/Blog.Core.Extensions/Middlewares/IpLogMiddleware.cs
@@ -60,7 +60,7 @@ namespace Blog.Core.Extensions.Middlewares
                             Parallel.For(0, 1, e =>
                             {
                                 //LogLock.OutSql2Log("RequestIpInfoLog", new string[] { requestInfo + "," }, false);
-                                LogLock.OutLogAOP("RequestIpInfoLog", new string[] { requestInfo.GetType().ToString(), requestInfo }, false);
+                                LogLock.OutLogAOP("RequestIpInfoLog", context.TraceIdentifier, new string[] { requestInfo.GetType().ToString(), requestInfo }, false);
                             });
 
                             //try

--- a/Blog.Core.Extensions/Middlewares/RecordAccessLogsMiddleware.cs
+++ b/Blog.Core.Extensions/Middlewares/RecordAccessLogsMiddleware.cs
@@ -109,7 +109,7 @@ namespace Blog.Core.Extensions.Middlewares
                         Parallel.For(0, 1, e =>
                         {
                             //LogLock.OutSql2Log("RecordAccessLogs", new string[] { requestInfo + "," }, false);
-                            LogLock.OutLogAOP("RecordAccessLogs", new string[] { userAccessModel.GetType().ToString(), requestInfo }, false);
+                            LogLock.OutLogAOP("RecordAccessLogs", context.TraceIdentifier, new string[] { userAccessModel.GetType().ToString(), requestInfo }, false);
                         });
                         //var logFileName = FileHelper.GetAvailableFileNameWithPrefixOrderSize(_environment.ContentRootPath, "RecordAccessLogs");
                         //SerilogServer.WriteLog(logFileName, new string[] { requestInfo + "," }, false);

--- a/Blog.Core.Extensions/Middlewares/RequRespLogMiddleware.cs
+++ b/Blog.Core.Extensions/Middlewares/RequRespLogMiddleware.cs
@@ -102,7 +102,7 @@ namespace Blog.Core.Extensions.Middlewares
                 Parallel.For(0, 1, e =>
                 {
                     //LogLock.OutSql2Log("RequestResponseLog", new string[] { "Request Data:", content });
-                    LogLock.OutLogAOP("RequestResponseLog", new string[] { "Request Data -  RequestJsonDataType:" + requestResponse.GetType().ToString(), content });
+                    LogLock.OutLogAOP("RequestResponseLog", context.TraceIdentifier, new string[] { "Request Data -  RequestJsonDataType:" + requestResponse.GetType().ToString(), content });
 
                 });
                 //SerilogServer.WriteLog("RequestResponseLog", new string[] { "Request Data:", content });
@@ -125,7 +125,7 @@ namespace Blog.Core.Extensions.Middlewares
                 Parallel.For(0, 1, e =>
                 {
                     //LogLock.OutSql2Log("RequestResponseLog", new string[] { "Response Data:", ResponseBody });
-                    LogLock.OutLogAOP("RequestResponseLog", new string[] { "Response Data -  ResponseJsonDataType:" + responseBody.GetType().ToString(), responseBody });
+                    LogLock.OutLogAOP("RequestResponseLog", response.HttpContext.TraceIdentifier, new string[] { "Response Data -  ResponseJsonDataType:" + responseBody.GetType().ToString(), responseBody });
 
                 });
                 //SerilogServer.WriteLog("RequestResponseLog", new string[] { "Response Data:", responseBody });

--- a/Blog.Core.Extensions/ServiceExtensions/SqlsugarSetup.cs
+++ b/Blog.Core.Extensions/ServiceExtensions/SqlsugarSetup.cs
@@ -67,7 +67,7 @@ namespace Blog.Core.Extensions
                                         {
                                             MiniProfiler.Current.CustomTiming("SQL：", GetParas(p) + "【SQL语句】：" + sql);
                                             //LogLock.OutSql2Log("SqlLog", new string[] { GetParas(p), "【SQL语句】：" + sql });
-                                            LogLock.OutLogAOP("SqlLog", new string[] { sql.GetType().ToString(), GetParas(p), "【SQL语句】：" + sql });
+                                            LogLock.OutLogAOP("SqlLog","", new string[] { sql.GetType().ToString(), GetParas(p), "【SQL语句】：" + sql });
 
                                         });
                                     }

--- a/Blog.Core.Model/Models/GblLogAudit.cs
+++ b/Blog.Core.Model/Models/GblLogAudit.cs
@@ -16,6 +16,12 @@ namespace Blog.Core.Model.Models
         public int Id { get; set; }
 
         ///<summary>
+        ///HttpContext.TraceIdentifier 事件链路ID（获取或设置一个唯一标识符，用于在跟踪日志中表示此请求。）
+        ///</summary>
+        [SugarColumn(ColumnDescription = "事件链路ID", IsNullable = false, IsPrimaryKey = false, IsIdentity = false, ColumnDataType = "varchar", Length = 255)]
+        public string TraceId { get; set; }
+
+        ///<summary>
         ///时间
         ///</summary>
         [SugarColumn(ColumnDescription = "时间", IsNullable = false, IsPrimaryKey = false, IsIdentity = false, ColumnDataType = "datetime")]

--- a/Blog.Core.Tasks/QuartzNet/Jobs/Job_AccessTrendLog_Quartz.cs
+++ b/Blog.Core.Tasks/QuartzNet/Jobs/Job_AccessTrendLog_Quartz.cs
@@ -93,7 +93,7 @@ namespace Blog.Core.Tasks
 
             Parallel.For(0, 1, e =>
             {
-                LogLock.OutLogAOP("ACCESSTRENDLOG", new string[] { activeUserVMs.GetType().ToString(), JsonConvert.SerializeObject(activeUserVMs) }, false, true);
+                LogLock.OutLogAOP("ACCESSTRENDLOG","",new string[] { activeUserVMs.GetType().ToString(), JsonConvert.SerializeObject(activeUserVMs) }, false);
             });
         }
 


### PR DESCRIPTION
日志审计加入TraceId，链路ID用于查询整个请求所有相关日志，HttpContext.TraceIdentifier 属性（获取或设置一个唯一标识符，用于在跟踪日志中表示此请求。）
目前sql打印的没有加入和计划调度的没有添加TraceId
![1669270401664](https://user-images.githubusercontent.com/24422140/203707663-0a3c66c8-d1ca-4202-86c6-e9cf82805ace.jpg)
目前发现不同部署方式生成的ID不一样，IIS部署的是GUID，core运行的Kestrel是返回类似这种，机器+编码的形式0HMMDS8ODK2HI:00000004

压力测试在3秒内100个请求测试，ID不会重复，暂没加入雪花生成ID
![f2169cf8ead3518fece2ae169f5638b](https://user-images.githubusercontent.com/24422140/203707986-5a51ffec-0ffa-4122-9946-7ee99ba3bee4.png)
![fe4604804ebde5e9aad1ea7d6145507](https://user-images.githubusercontent.com/24422140/203707996-0ec5bba3-e8b5-42f1-b158-5e82e6c46353.png)
![cc780fb996db6037c4de627ab068a56](https://user-images.githubusercontent.com/24422140/203708008-8f4bfa2e-1c08-4b43-80ce-38f96550b449.png)
