### PR TITLE
添加公共项目属性配置文件

### DIFF
--- a/Blog.Core.Api/Blog.Core.Api.csproj
+++ b/Blog.Core.Api/Blog.Core.Api.csproj
@@ -1,10 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
+  <Import Project="..\build\common.targets" />
   <PropertyGroup>
-
     <OutputType>Exe</OutputType>
-
-    <TargetFramework>net7.0</TargetFramework>
 	<ImplicitUsings>enable</ImplicitUsings>
     <!--<AspNetCoreHostingModel>OutOfProcess</AspNetCoreHostingModel>-->
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>

--- a/Blog.Core.Common/Blog.Core.Common.csproj
+++ b/Blog.Core.Common/Blog.Core.Common.csproj
@@ -1,8 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-  </PropertyGroup>
+  <Import Project="..\build\common.targets" />
 
   <ItemGroup>
     <Compile Remove="HttpRestSharp\**" />

--- a/Blog.Core.EventBus/Blog.Core.EventBus.csproj
+++ b/Blog.Core.EventBus/Blog.Core.EventBus.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-  </PropertyGroup>
+  <Import Project="..\build\common.targets" />
 
 
   <ItemGroup>

--- a/Blog.Core.Extensions/Blog.Core.Extensions.csproj
+++ b/Blog.Core.Extensions/Blog.Core.Extensions.csproj
@@ -1,8 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-  </PropertyGroup>
+  <Import Project="..\build\common.targets" />
 
   <ItemGroup>
     <PackageReference Include="AspNetCoreRateLimit" Version="5.0.0" />

--- a/Blog.Core.FrameWork/Blog.Core.FrameWork.csproj
+++ b/Blog.Core.FrameWork/Blog.Core.FrameWork.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-  </PropertyGroup>
+  <Import Project="..\build\common.targets" />
 
   <ItemGroup>
     <None Update="Blog.Core.FrameWork.Entity\Blog.Core.FrameWork.tt">

--- a/Blog.Core.Gateway/Blog.Core.Gateway.csproj
+++ b/Blog.Core.Gateway/Blog.Core.Gateway.csproj
@@ -1,8 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-  </PropertyGroup>
+  <Import Project="..\build\common.targets" />
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DocumentationFile>..\Blog.Core.Gateway\Blog.Core.Gateway.xml</DocumentationFile>

--- a/Blog.Core.IServices/Blog.Core.IServices.csproj
+++ b/Blog.Core.IServices/Blog.Core.IServices.csproj
@@ -1,8 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-  </PropertyGroup>
+  <Import Project="..\build\common.targets" />
 
   <ItemGroup>
     <ProjectReference Include="..\Blog.Core.Common\Blog.Core.Common.csproj" />

--- a/Blog.Core.Model/Blog.Core.Model.csproj
+++ b/Blog.Core.Model/Blog.Core.Model.csproj
@@ -1,8 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
-	</PropertyGroup>
+	<Import Project="..\build\common.targets" />
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
 		<DocumentationFile>..\Blog.Core.Api\Blog.Core.Model.xml</DocumentationFile>

--- a/Blog.Core.Repository/Blog.Core.Repository.csproj
+++ b/Blog.Core.Repository/Blog.Core.Repository.csproj
@@ -1,8 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
-	</PropertyGroup>
+	<Import Project="..\build\common.targets" />
 
 
   <ItemGroup>

--- a/Blog.Core.Serilog.Es/Blog.Core.Serilog.Es.csproj
+++ b/Blog.Core.Serilog.Es/Blog.Core.Serilog.Es.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-  </PropertyGroup>
+	<Import Project="..\build\common.targets" />
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />

--- a/Blog.Core.Services/Blog.Core.Services.csproj
+++ b/Blog.Core.Services/Blog.Core.Services.csproj
@@ -1,8 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
-	</PropertyGroup>
+	<Import Project="..\build\common.targets" />
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
 		<OutputPath>..\Blog.Core.Api\bin\Debug\</OutputPath>

--- a/Blog.Core.Tasks/Blog.Core.Tasks.csproj
+++ b/Blog.Core.Tasks/Blog.Core.Tasks.csproj
@@ -1,8 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-  </PropertyGroup>
+	<Import Project="..\build\common.targets" />
 
   <ItemGroup>
     <PackageReference Include="Quartz" Version="3.5.0" />

--- a/Blog.Core.Tests/Blog.Core.Tests.csproj
+++ b/Blog.Core.Tests/Blog.Core.Tests.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="..\build\common.targets" />
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-
     <IsPackable>false</IsPackable>
 	<ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
   </PropertyGroup>

--- a/Ocelot.Provider.Nacos/Ocelot.Provider.Nacos.csproj
+++ b/Ocelot.Provider.Nacos/Ocelot.Provider.Nacos.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
+	
+  <Import Project="..\build\common.targets" />
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
     <Copyright>softlgl</Copyright>
     <Owners>softlgl</Owners>
     <PackageProjectUrl>https://github.com/softlgl/Ocelot.Provider.Nacos</PackageProjectUrl>

--- a/build/common.targets
+++ b/build/common.targets
@@ -1,0 +1,5 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+    </PropertyGroup>
+</Project>


### PR DESCRIPTION
将`TargetFramework`属性迁移到`common.targets`作为方便管理
[参考](https://learn.microsoft.com/zh-cn/visualstudio/msbuild/how-to-use-the-same-target-in-multiple-project-files?view=vs-2022)