### PR TITLE
将 `int jobid` 的类型更改为 `long jobid`，再添加任务时候，创建的ID为雪花ID

### DIFF
--- a/Blog.Core.Tasks/QuartzNet/Jobs/JobBase.cs
+++ b/Blog.Core.Tasks/QuartzNet/Jobs/JobBase.cs
@@ -27,7 +27,7 @@ namespace Blog.Core.Tasks
             //记录Job
             TasksLog tasksLog = new TasksLog();
             //JOBID
-            int jobid = context.JobDetail.Key.Name.ObjToInt();
+            long jobid = context.JobDetail.Key.Name.ObjToLong();
             //JOB组名
             string groupName = context.JobDetail.Key.Group;
             //日志


### PR DESCRIPTION
将 `int jobid` 的类型更改为 `long jobid`，再添加任务时候，创建的ID为雪花ID，而任务程序在获取jobid时，使用了int.TryParse，导致id转换失败